### PR TITLE
Add support for structures without references

### DIFF
--- a/BinData.Tests/Deserializer/ValueTypeDeserializerTests.cs
+++ b/BinData.Tests/Deserializer/ValueTypeDeserializerTests.cs
@@ -170,6 +170,16 @@ public class ValueTypeDeserializerTests
     }
 
     [Fact]
+    public void TypedDateTimeTest()
+    {
+        var value = new byte[] { 0x00, 0x1a, 0x26, 0xaa, 0xc4, 0x95, 0x1e, 0x01 };
+        var actual = BinaryConvert.Deserialize<DateTime>(value);
+        var expected = new DateTime(256, 8, 16, 0, 32, 4);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void TypedStringTest()
     {
         var value = new byte[]

--- a/BinData.Tests/Serializer/ValueTypeSerializerTests.cs
+++ b/BinData.Tests/Serializer/ValueTypeSerializerTests.cs
@@ -140,6 +140,16 @@ public class ValueTypeSerializerTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact]
+    public void DateTimeTest()
+    {
+        var value = new DateTime(256, 8, 16, 0, 32, 4);
+        var actual = BinaryConvert.Serialize(value);
+        var expected = new byte[] { 0x00, 0x1a, 0x26, 0xaa, 0xc4, 0x95, 0x1e, 0x01 };
+
+        Assert.Equal(expected, actual);
+    }
+
     public static IEnumerable<object[]> GetValueTupleData()
     {
         yield return new object[]

--- a/BinData/BinaryStreamReader.cs
+++ b/BinData/BinaryStreamReader.cs
@@ -107,4 +107,18 @@ internal static class BinaryStreamReader
 
         return bytes;
     }
+
+    public static unsafe T ReadStructure<T>(Stream stream) where T : unmanaged
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(T)];
+        if (stream.Read(buffer) < sizeof(T))
+            ThrowHelper.ThrowEndOfStreamException();
+
+        if (!BitConverter.IsLittleEndian)
+        {
+            buffer.Reverse();
+        }
+
+        return MemoryMarshal.Read<T>(buffer);
+    }
 }

--- a/BinData/BinaryStreamWriter.cs
+++ b/BinData/BinaryStreamWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace BinData;
@@ -80,5 +81,18 @@ internal static class BinaryStreamWriter
 
         stream.Write(buffer);
         stream.Write(bytes);
+    }
+
+    public static unsafe void WriteStructure<T>(T value, Stream stream) where T : unmanaged
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(T)];
+        MemoryMarshal.Write(buffer, ref value);
+
+        if (!BitConverter.IsLittleEndian)
+        {
+            buffer.Reverse();
+        }
+
+        stream.Write(buffer);
     }
 }


### PR DESCRIPTION
This change adds support for (de)serialization of any structure that doesn't contain any references = is unamanged. Example of such structure is `DateTime`