### PR TITLE
Add protocol format documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# BinData documentation
+
+[protocol.md](https://github.com/ndelta0/BinData/tree/main/docs/protocol.md) - documentation of serialized data format

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -16,9 +16,19 @@ Enumeration types, known as `enum`s in C#, are (de)serialized as a number. Numbe
 
 BinData supports all [C# primitive types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types). All of them are written/read as little-endian. There is a slight exception for the `decimal` type (16-byte floating-point number), which is written/read as four little-endian 4-byte signed integers.
 
+|Type|Value|Bytes|
+|:---|-----|-----|
+|int |1    | 0x01 0x00 0x00 0x00 |
+
 ## Strings
 
 *See [reference types](#reference-types).* Strings are length-prefixed with a little-endian 4-byte signed integer. Length prefix tells you how many bytes there are (not how long the string is). Used encoding is UTF-8.
+
+|Type  |Value |Bytes|
+|:-----|------|-----|
+|string|null  | *0x00* |
+|string|""    | *0x01* 0x00 0x00 0x00 0x00 |
+|string|"Test"| *0x01* 0x04 0x00 0x00 0x00 **0x54 0x65 0x73 0x74** |
 
 ## Arrays and Lists
 
@@ -36,9 +46,18 @@ BinData allows for (de)serialization of `struct`s, **unless** they contain refer
 
 *Don't mistake with [value tuples](#value-tuples). See [reference types](#reference-types).* Tuples (de)serialize their members in the same order as they are declared.
 
+|Type             |Value            |Bytes|
+|:----------------|-----------------|-----|
+|Tuple<bool, bool>|null             | *0x00* |
+|Tuple<bool, bool>|new (true, false)| *0x01* 0x01 0x00 |
+
 ## Value tuples
 
 Value tuples serialize their members in the same order as they are declared.
+
+|Type                  |Value        |Bytes|
+|:---------------------|-------------|-----|
+|ValueTuple<bool, bool>|(true, false)| 0x01 0x00 |
 
 ### Tuples vs. Value tuples
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,53 @@
+# BinData Protocol
+
+BinData (de)serializes objects in a deterministic manner. All values are written/read as little-endian.
+
+## Reference types
+
+Types that are by-reference -- can be `null`, have a single byte prefix. The byte prefix is `1` when value is **not** `null` and `0` when value is `null`.
+- `null` → `0`, no data follows
+- not `null` → `1`, data follows
+
+## Enumeration types
+
+Enumeration types, known as `enum`s in C#, are (de)serialized as a number. Number type is the same as the [enum's underlying type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum).
+
+## Primitives
+
+BinData supports all [C# primitive types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types). All of them are written/read as little-endian. There is a slight exception for the `decimal` type (16-byte floating-point number), which is written/read as four little-endian 4-byte signed integers.
+
+## Strings
+
+*See [reference types](#reference-types).* Strings are length-prefixed with a little-endian 4-byte signed integer. Length prefix tells you how many bytes there are (not how long the string is). Used encoding is UTF-8.
+
+## Arrays and Lists
+
+*See [reference types](#reference-types).* Arrays and `List<>`s are length-prefixed with a little-endian 4-byte signed integer.
+
+## Classes
+
+*See [reference types](#reference-types).* First, public instance properties are (de)serialized. Then all instance fields (even non-public) are (de)serialized. (De)serialization order of members is the same as the order in which they are declared.
+
+## Structures
+
+BinData allows for (de)serialization of `struct`s, **unless** they contain references. Structures are seen as a single sequence of bytes. On big-endian systems, the byte order is reversed to ensure little-endianness. (Note that this does not provide complete endianness-safety and may cause issues).
+
+## Tuples
+
+*Don't mistake with [value tuples](#value-tuples). See [reference types](#reference-types).* Tuples (de)serialize their members in the same order as they are declared.
+
+## Value tuples
+
+Value tuples serialize their members in the same order as they are declared.
+
+### Tuples vs. Value tuples
+
+The only difference is that, since `Tuple` is a reference type, it may be `null` and has a [byte prefix](#reference-types).
+
+## Nullable value types
+BinData supports [`Nullable<>`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types), which allows value types to be treated as [reference types](#reference-types).
+
+## Interface shadowing
+
+When deserializing certain interfaces, BinData selects implementation type:
+- `IEnumerable<>` → `List<>`


### PR DESCRIPTION
Adds markdown documentation for how data is formatted.

`docs/README.md` - overview of all documentation
`docs/protocol.md` - protocol documentation